### PR TITLE
Add standard toHex procedures.

### DIFF
--- a/nimSHA2.nim
+++ b/nimSHA2.nim
@@ -402,4 +402,9 @@ proc toHexImpl[T](input: T): string =
 proc hex*(sha: SHA224Digest): string = toHexImpl(sha)
 proc hex*(sha: SHA256Digest): string = toHexImpl(sha)
 proc hex*(sha: SHA384Digest): string = toHexImpl(sha)
-proc hex*(sha: SHA512Digest): string = toHexImpl(sha)  
+proc hex*(sha: SHA512Digest): string = toHexImpl(sha)
+
+proc toHex*(sha: SHA224Digest): string = toHexImpl(sha)
+proc toHex*(sha: SHA256Digest): string = toHexImpl(sha)
+proc toHex*(sha: SHA384Digest): string = toHexImpl(sha)
+proc toHex*(sha: SHA512Digest): string = toHexImpl(sha)  


### PR DESCRIPTION
Add standard toHex procedures and fix backwards compatibility.
Some packages (hmac) don't work anymore because this package no longer has (or never did?) have toHex procedures.